### PR TITLE
updated notification types to bootstrap names

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -50,7 +50,7 @@ class App extends \Prefab
         }
 
         // these take multiple paths
-        $language = $f3->get('LANGUAGE');
+	$language = substr($f3->get('LANGUAGE'),0,2);
         foreach (['LOCALES', 'UI'] as $key) {
             $paths = $f3->get($key);
                 // remove any invalid dirs

--- a/src/Helpers/Notifications.php
+++ b/src/Helpers/Notifications.php
@@ -16,7 +16,7 @@ class Notifications extends \Prefab
 
     public static $types = [
         'success',
-        'error',
+        'danger',
         'warning',
         'info',
         'debug'


### PR DESCRIPTION
In the used bootstrap version there is no alert-error, but an alert-danger. 